### PR TITLE
Adding support for netstandard2.0

### DIFF
--- a/src/MarcusW.VncClient/MarcusW.VncClient.csproj
+++ b/src/MarcusW.VncClient/MarcusW.VncClient.csproj
@@ -1,12 +1,20 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 
     <ItemGroup>
       <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" PrivateAssets="all" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.3" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+      <PackageReference Include="System.Memory" Version="4.5.4"/>
+      <PackageReference Include="System.Collections.Immutable" Version="5.0.0"/>
+      <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0"/>
+      <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/MarcusW.VncClient/PixelFormat.cs
+++ b/src/MarcusW.VncClient/PixelFormat.cs
@@ -147,7 +147,11 @@ namespace MarcusW.VncClient
         /// <param name="other">The other pixel format.</param>
         /// <param name="ignoreAlpha">If true, the presence and encoding of the alpha channel will be ignored during this check.</param>
         /// <returns>True if they are binary compatible, otherwise false.</returns>
+#if NETSTANDARD2_0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#else
         [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+#endif
         public bool IsBinaryCompatibleTo(PixelFormat other, bool ignoreAlpha = false)
         {
             if (BitsPerPixel != other.BitsPerPixel || BigEndian != other.BigEndian || TrueColor != other.TrueColor)

--- a/src/MarcusW.VncClient/Protocol/Implementation/DefaultImplementation.cs
+++ b/src/MarcusW.VncClient/Protocol/Implementation/DefaultImplementation.cs
@@ -152,6 +152,7 @@ namespace MarcusW.VncClient.Protocol.Implementation
             yield return new PointerEventMessageType();
             yield return new KeyEventMessageType();
             yield return new SetDesktopSizeMessageType(context);
+            yield return new ClientCutTextMessageType();
         }
 
         /// <summary>

--- a/src/MarcusW.VncClient/Protocol/Implementation/EncodingTypes/Frame/RawEncodingType.cs
+++ b/src/MarcusW.VncClient/Protocol/Implementation/EncodingTypes/Frame/RawEncodingType.cs
@@ -33,7 +33,11 @@ namespace MarcusW.VncClient.Protocol.Implementation.EncodingTypes.Frame
         public override Color VisualizationColor => new Color(0, 0, 255);
 
         /// <inheritdoc />
-        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+#if NETSTANDARD2_0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#else
+        [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+#endif
         public override void ReadFrameEncoding(Stream transportStream, IFramebufferReference? targetFramebuffer, in Rectangle rectangle, in Size remoteFramebufferSize,
             in PixelFormat remoteFramebufferFormat)
         {

--- a/src/MarcusW.VncClient/Protocol/Implementation/EncodingTypes/Frame/TightEncodingType.cs
+++ b/src/MarcusW.VncClient/Protocol/Implementation/EncodingTypes/Frame/TightEncodingType.cs
@@ -104,7 +104,11 @@ namespace MarcusW.VncClient.Protocol.Implementation.EncodingTypes.Frame
             return remoteFramebufferFormat;
         }
 
+#if NETSTANDARD2_0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#else
         [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+#endif
         private void ReadBasicCompressedRectangle(Stream stream, bool hasTargetFramebuffer, ref FramebufferCursor framebufferCursor, in Rectangle rectangle,
             in PixelFormat tPixelFormat, int zlibStreamId, bool readFilterId)
         {
@@ -136,7 +140,11 @@ namespace MarcusW.VncClient.Protocol.Implementation.EncodingTypes.Frame
             }
         }
 
+#if NETSTANDARD2_0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#else
         [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+#endif
         private void ReadBasicCompressedCopyFilterRectangle(Stream stream, bool hasTargetFramebuffer, ref FramebufferCursor framebufferCursor, in Rectangle rectangle,
             in PixelFormat tPixelFormat, int zlibStreamId)
         {
@@ -184,7 +192,11 @@ namespace MarcusW.VncClient.Protocol.Implementation.EncodingTypes.Frame
             }
         }
 
+#if NETSTANDARD2_0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#else
         [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+#endif
         private void ReadBasicCompressedPaletteFilterRectangle(Stream stream, bool hasTargetFramebuffer, ref FramebufferCursor framebufferCursor, in Rectangle rectangle,
             in PixelFormat tPixelFormat, int zlibStreamId)
         {
@@ -272,7 +284,11 @@ namespace MarcusW.VncClient.Protocol.Implementation.EncodingTypes.Frame
             }
         }
 
+#if NETSTANDARD2_0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#else
         [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+#endif
         private Stream GetBasicCompressedPixelDataStream(Stream baseStream, int expectedLength, int zlibStreamId)
         {
             // No zlib compression is used for small data chunks
@@ -287,7 +303,11 @@ namespace MarcusW.VncClient.Protocol.Implementation.EncodingTypes.Frame
             return _context.ZLibInflater.ReadAndInflate(baseStream, zlibDataLength, zlibStreamId);
         }
 
+#if NETSTANDARD2_0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#else
         [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+#endif
         private void ReadFillCompressedRectangle(Stream stream, bool hasTargetFramebuffer, ref FramebufferCursor framebufferCursor, in Rectangle rectangle,
             in PixelFormat tPixelFormat)
         {
@@ -307,7 +327,11 @@ namespace MarcusW.VncClient.Protocol.Implementation.EncodingTypes.Frame
             }
         }
 
+#if NETSTANDARD2_0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#else
         [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+#endif
         private void ReadJpegCompressedRectangle(Stream stream, bool hasTargetFramebuffer, ref FramebufferCursor framebufferCursor, in Rectangle rectangle)
         {
             Debug.Assert(_context.JpegDecoder != null, "_context.JpegDecoder != null");
@@ -354,7 +378,11 @@ namespace MarcusW.VncClient.Protocol.Implementation.EncodingTypes.Frame
             }
         }
 
+#if NETSTANDARD2_0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#else
         [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+#endif
         private uint ReadCompactNumber(Stream stream)
         {
             uint number = 0; // 0x zzzzzzzz yyyyyyy xxxxxxx

--- a/src/MarcusW.VncClient/Protocol/Implementation/EncodingTypes/Frame/ZrleEncodingType.cs
+++ b/src/MarcusW.VncClient/Protocol/Implementation/EncodingTypes/Frame/ZrleEncodingType.cs
@@ -46,7 +46,11 @@ namespace MarcusW.VncClient.Protocol.Implementation.EncodingTypes.Frame
         }
 
         /// <inheritdoc />
-        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+#if NETSTANDARD2_0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#else
+        [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+#endif
         public override void ReadFrameEncoding(Stream transportStream, IFramebufferReference? targetFramebuffer, in Rectangle rectangle, in Size remoteFramebufferSize,
             in PixelFormat remoteFramebufferFormat)
         {
@@ -134,11 +138,16 @@ namespace MarcusW.VncClient.Protocol.Implementation.EncodingTypes.Frame
             return remoteFramebufferFormat;
         }
 
+#if NETSTANDARD2_0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#else
         [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+#endif
         private void ReadTile(Stream stream, IFramebufferReference? targetFramebuffer, in Rectangle tile, in PixelFormat cPixelFormat)
         {
             // Read one byte for the subencoding type
             Span<byte> subencodingTypeBuffer = stackalloc byte[1];
+
             if (stream.Read(subencodingTypeBuffer) == 0)
                 throw new UnexpectedEndOfStreamException("Stream reached its end while reading tile subencoding type.");
             byte subencodingType = subencodingTypeBuffer[0];
@@ -192,7 +201,11 @@ namespace MarcusW.VncClient.Protocol.Implementation.EncodingTypes.Frame
             }
         }
 
+#if NETSTANDARD2_0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#else
         [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+#endif
         private void ReadRawTile(Stream stream, bool hasTargetFramebuffer, ref FramebufferCursor framebufferCursor, in Rectangle tile, in PixelFormat cPixelFormat)
         {
             // Calculate how many bytes we're going to receive
@@ -226,7 +239,11 @@ namespace MarcusW.VncClient.Protocol.Implementation.EncodingTypes.Frame
             }
         }
 
+#if NETSTANDARD2_0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#else
         [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+#endif
         private void ReadSolidTile(Stream stream, bool hasTargetFramebuffer, ref FramebufferCursor framebufferCursor, in Rectangle tile, in PixelFormat cPixelFormat)
         {
             // Read a single color value
@@ -245,7 +262,11 @@ namespace MarcusW.VncClient.Protocol.Implementation.EncodingTypes.Frame
             }
         }
 
+#if NETSTANDARD2_0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#else
         [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+#endif
         private void ReadPackedPaletteTile(Stream stream, bool hasTargetFramebuffer, ref FramebufferCursor framebufferCursor, in Rectangle tile, in PixelFormat cPixelFormat,
             int paletteSize)
         {
@@ -316,7 +337,11 @@ namespace MarcusW.VncClient.Protocol.Implementation.EncodingTypes.Frame
             }
         }
 
+#if NETSTANDARD2_0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#else
         [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+#endif
         private void ReadRleTile(Stream stream, bool hasTargetFramebuffer, ref FramebufferCursor framebufferCursor, in Rectangle tile, in PixelFormat cPixelFormat)
         {
             Span<byte> buffer = _tileBuffer.AsSpan();
@@ -358,7 +383,11 @@ namespace MarcusW.VncClient.Protocol.Implementation.EncodingTypes.Frame
             }
         }
 
+#if NETSTANDARD2_0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#else
         [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+#endif
         private void ReadPaletteRleTile(Stream stream, bool hasTargetFramebuffer, ref FramebufferCursor framebufferCursor, in Rectangle tile, in PixelFormat cPixelFormat,
             int paletteSize)
         {

--- a/src/MarcusW.VncClient/Protocol/Implementation/FramebufferCursor.cs
+++ b/src/MarcusW.VncClient/Protocol/Implementation/FramebufferCursor.cs
@@ -75,13 +75,21 @@ namespace MarcusW.VncClient.Protocol.Implementation
         /// <summary>
         /// Gets whether the cursor reached the last pixel of the rectangle.
         /// </summary>
+#if NETSTANDARD2_0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#else
         [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+#endif
         public bool GetEndReached() => _currentY == LastY && _currentX == LastX;
 
         /// <summary>
         /// Moves the cursor to the next pixel of the rectangle.
         /// </summary>
+#if NETSTANDARD2_0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#else
         [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+#endif
         public void MoveNext()
         {
             // Return to line start when line end is reached
@@ -107,7 +115,11 @@ namespace MarcusW.VncClient.Protocol.Implementation
         /// Moves the cursor a few pixels forward in the current line.
         /// </summary>
         /// <param name="count">The amount of pixels to move the cursor forward.</param>
+#if NETSTANDARD2_0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#else
         [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+#endif
         public void MoveForwardInLine(int count)
         {
             // Check for line overflow
@@ -123,7 +135,11 @@ namespace MarcusW.VncClient.Protocol.Implementation
         /// Sets the pixel color on the current position in the rectangle.
         /// </summary>
         /// <param name="color">The desired color.</param>
+#if NETSTANDARD2_0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#else
         [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+#endif
         public void SetPixel(Color color)
         {
             uint pixelData = color.ToPlainPixel();
@@ -135,7 +151,11 @@ namespace MarcusW.VncClient.Protocol.Implementation
         /// </summary>
         /// <param name="pixelData">A pointer to a memory location where the color data is stored.</param>
         /// <param name="pixelFormat">The format of the pixel data.</param>
+#if NETSTANDARD2_0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#else
         [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+#endif
         public void SetPixel(byte* pixelData, in PixelFormat pixelFormat)
         {
             PixelConversions.WritePixel(pixelData, pixelFormat, _positionPtr, FramebufferFormat);
@@ -146,7 +166,11 @@ namespace MarcusW.VncClient.Protocol.Implementation
         /// </summary>
         /// <param name="color">The desired color.</param>
         /// <param name="numPixels">The number of pixels to set.</param>
+#if NETSTANDARD2_0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#else
         [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+#endif
         public void SetPixelsSolid(Color color, int numPixels)
         {
             uint pixelData = color.ToPlainPixel();
@@ -159,7 +183,11 @@ namespace MarcusW.VncClient.Protocol.Implementation
         /// <param name="pixelData">A pointer to a memory location where the color data is stored.</param>
         /// <param name="pixelFormat">The format of the pixel data.</param>
         /// <param name="numPixels">The number of pixels to set.</param>
+#if NETSTANDARD2_0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#else
         [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+#endif
         public void SetPixelsSolid(byte* pixelData, in PixelFormat pixelFormat, int numPixels)
         {
             // Convert the pixel once
@@ -181,7 +209,11 @@ namespace MarcusW.VncClient.Protocol.Implementation
         /// <param name="pixelData">A pointer to a memory location where the data for <see cref="numPixels"/> is stored.</param>
         /// <param name="pixelFormat">The format of the pixel data.</param>
         /// <param name="numPixels">The number of pixels to set.</param>
+#if NETSTANDARD2_0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#else
         [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+#endif
         public void SetPixels(byte* pixelData, in PixelFormat pixelFormat, int numPixels)
         {
             // Fast path: When no conversion is necessary, we can copy the data line by line
@@ -246,7 +278,11 @@ namespace MarcusW.VncClient.Protocol.Implementation
         /// Both cursors must point to the start of their rectangle.
         /// The current cursor position is advanced by the written pixels, the other cursor won't be touched.
         /// </remarks>
+#if NETSTANDARD2_0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#else
         [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+#endif
         public void CopyAllFrom(ref FramebufferCursor otherCursor)
         {
             Rectangle otherRectangle = otherCursor.Rectangle;

--- a/src/MarcusW.VncClient/Protocol/Implementation/MessageTypes/Incoming/FramebufferUpdateMessageType.cs
+++ b/src/MarcusW.VncClient/Protocol/Implementation/MessageTypes/Incoming/FramebufferUpdateMessageType.cs
@@ -71,7 +71,10 @@ namespace MarcusW.VncClient.Protocol.Implementation.MessageTypes.Incoming
             if (transport == null)
                 throw new ArgumentNullException(nameof(transport));
 
-            cancellationToken.ThrowIfCancellationRequested();
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
 
             Stream transportStream = transport.Stream;
             Span<byte> buffer = _buffer.AsSpan();

--- a/src/MarcusW.VncClient/Protocol/Implementation/MessageTypes/Incoming/ServerCutTextMessageType.cs
+++ b/src/MarcusW.VncClient/Protocol/Implementation/MessageTypes/Incoming/ServerCutTextMessageType.cs
@@ -94,7 +94,11 @@ namespace MarcusW.VncClient.Protocol.Implementation.MessageTypes.Incoming
                         if (read == 0)
                             throw new UnexpectedEndOfStreamException("Stream reached its end while trying to read the server cut text.");
 
+#if NETSTANDARD2_0
+                        stringBuilder.Append(latin1Encoding.GetString(bufferSpan.Slice(0, read).ToArray()));
+#else
                         stringBuilder.Append(latin1Encoding.GetString(bufferSpan.Slice(0, read)));
+#endif
 
                         bytesToRead -= read;
                     }

--- a/src/MarcusW.VncClient/Protocol/Implementation/MessageTypes/Outgoing/ClientCutTextMessageType.cs
+++ b/src/MarcusW.VncClient/Protocol/Implementation/MessageTypes/Outgoing/ClientCutTextMessageType.cs
@@ -1,0 +1,92 @@
+using MarcusW.VncClient.Protocol.MessageTypes;
+using System;
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+
+namespace MarcusW.VncClient.Protocol.Implementation.MessageTypes.Outgoing
+{
+    public class ClientCutTextMessageType : IOutgoingMessageType
+    {
+        public byte Id => (byte) WellKnownOutgoingMessageType.ClientCutText;
+
+        public string Name => "ClientCutText";
+
+        public bool IsStandardMessageType => true;
+
+        public void WriteToTransport(IOutgoingMessage<IOutgoingMessageType> message, ITransport transport, CancellationToken cancellationToken = default)
+        {
+            if (message == null)
+                throw new ArgumentNullException(nameof(message));
+            if (transport == null)
+                throw new ArgumentNullException(nameof(transport));
+            if (!(message is ClientCutTextMessage clientCutMessage))
+                throw new ArgumentException($"Message is no {nameof(ClientCutTextMessage)}.", nameof(message));
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            Encoding latin1Encoding = Encoding.GetEncoding("ISO-8859-1");
+            int byteCount = latin1Encoding.GetByteCount(clientCutMessage.Text);
+
+            Span<byte> buffer = stackalloc byte[8 + byteCount];
+
+            // Message type
+            buffer[0] = Id;
+
+            // Padding
+            buffer[1] = 0;
+            buffer[2] = 0;
+            buffer[3] = 0;
+
+            BinaryPrimitives.WriteUInt32BigEndian(buffer[4..], Convert.ToUInt32(byteCount));
+            latin1Encoding.GetBytes(clientCutMessage.Text, buffer[8..]);
+
+            // Write message to stream
+            transport.Stream.Write(buffer);
+        }
+    }
+
+    public class ClientCutTextMessage : IOutgoingMessage<ClientCutTextMessageType>
+    {
+        public string Text { get; }
+
+        public ClientCutTextMessage(string text)
+        {
+            Text = text;
+        }
+
+        public string? GetParametersOverview() => $"Text: {Text}";
+    }
+
+#if NETSTANDARD2_0
+    public static class EncodingExtensions
+    {
+        public static int GetBytes(this Encoding encoding, string input, Span<byte> bytes)
+        {
+            byte[] sharedBuffer = ArrayPool<byte>.Shared.Rent(encoding.GetByteCount(input));
+
+            try
+            {
+                int numRead = encoding.GetBytes(input, 0, input.Length, sharedBuffer, 0);
+
+                if (numRead > bytes.Length)
+                {
+                    throw new IOException("Bytes read from the stream exceed the size of the buffer");
+                }
+
+                new Span<byte>(sharedBuffer, 0, numRead).CopyTo(bytes);
+
+                return numRead;
+            }
+
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(sharedBuffer);
+            }
+        }
+    }
+#endif
+}

--- a/src/MarcusW.VncClient/Protocol/Implementation/Native/TurboJpeg.cs
+++ b/src/MarcusW.VncClient/Protocol/Implementation/Native/TurboJpeg.cs
@@ -21,10 +21,22 @@ namespace MarcusW.VncClient.Protocol.Implementation.Native
         /// </summary>
         public static bool IsAvailable { get; }
 
+#if NETSTANDARD2_0
+        [DllImport("kernel32", SetLastError = true)]
+        private static extern IntPtr LoadLibrary(string dllToLoad);
+#endif
+
         // Static constructor to check for library availability.
         static TurboJpeg()
         {
+#if NETSTANDARD2_0
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            {
+                IsAvailable = LoadLibrary(LibraryName + ".dll") != IntPtr.Zero;
+            }
+#else
             IsAvailable = NativeLibrary.TryLoad(LibraryName, typeof(TurboJpeg).Assembly, null, out _);
+#endif
         }
 
         /// <summary>

--- a/src/MarcusW.VncClient/Protocol/Implementation/PixelConversions.cs
+++ b/src/MarcusW.VncClient/Protocol/Implementation/PixelConversions.cs
@@ -2,7 +2,7 @@ using System;
 using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Runtime.Intrinsics.X86;
+
 
 namespace MarcusW.VncClient.Protocol.Implementation
 {
@@ -18,7 +18,11 @@ namespace MarcusW.VncClient.Protocol.Implementation
         /// <param name="pixelFormat">The format of the source pixel data.</param>
         /// <param name="targetPtr">The position for the target pixel data.</param>
         /// <param name="targetFormat">The format for the target pixel data.</param>
+#if NETSTANDARD2_0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#else
         [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+#endif
         public static unsafe void WritePixel(byte* pixelPtr, in PixelFormat pixelFormat, byte* targetPtr, in PixelFormat targetFormat)
         {
             if (!pixelFormat.TrueColor || !targetFormat.TrueColor)
@@ -34,7 +38,11 @@ namespace MarcusW.VncClient.Protocol.Implementation
             WritePixelGenericPath(pixelPtr, pixelFormat, targetPtr, targetFormat);
         }
 
+#if NETSTANDARD2_0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#else
         [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+#endif
         private static unsafe bool WritePixelFastPath(byte* pixelPtr, in PixelFormat pixelFormat, byte* targetPtr, in PixelFormat targetFormat)
         {
             if (pixelFormat.BigEndian == targetFormat.BigEndian)
@@ -91,7 +99,11 @@ namespace MarcusW.VncClient.Protocol.Implementation
             return false;
         }
 
+#if NETSTANDARD2_0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#else
         [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+#endif
         private static unsafe void WritePixelGenericPath(byte* pixelPtr, in PixelFormat pixelFormat, byte* targetPtr, in PixelFormat targetFormat)
         {
             // Read the corresponding bits, ensure it's LE and put them to the right (of the native representation) of a 32bit uint so we can easier work with it.
@@ -152,7 +164,11 @@ namespace MarcusW.VncClient.Protocol.Implementation
             }
         }
 
+#if NETSTANDARD2_0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#else
         [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+#endif
         private static void CopyChannelValue(uint srcValue, ref uint dstValue, ushort srcMax, byte srcShift, ushort dstMax, byte dstShift)
         {
             // Retrieve channel value from the source

--- a/src/MarcusW.VncClient/Protocol/Implementation/PixelUtils.cs
+++ b/src/MarcusW.VncClient/Protocol/Implementation/PixelUtils.cs
@@ -1,5 +1,7 @@
 using System.Runtime.CompilerServices;
+#if NETCOREAPP3_1
 using System.Runtime.Intrinsics.X86;
+#endif
 
 namespace MarcusW.VncClient.Protocol.Implementation
 {
@@ -13,12 +15,18 @@ namespace MarcusW.VncClient.Protocol.Implementation
         /// </summary>
         /// <param name="maxValue">The maximum value for the color channel.</param>
         /// <returns>The channel depth.</returns>
+#if NETSTANDARD2_0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#else
         [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+#endif
         public static byte GetChannelDepth(ushort maxValue)
         {
+#if NETCOREAPP3_1
             // If the hardware instruction is available, use this one, because it's WAY faster...
             if (Popcnt.IsSupported)
                 return (byte)Popcnt.PopCount(maxValue);
+#endif
 
             // Fallback: https://en.wikichip.org/wiki/population_count#Implementations
             // TODO: Probably there is something faster for this special use case, but mostly popcnt will be available anyway.

--- a/src/MarcusW.VncClient/Protocol/Implementation/SecurityTypes/VncAuthenticationSecurityType.cs
+++ b/src/MarcusW.VncClient/Protocol/Implementation/SecurityTypes/VncAuthenticationSecurityType.cs
@@ -59,7 +59,12 @@ namespace MarcusW.VncClient.Protocol.Implementation.SecurityTypes
 
             // Send response
             Debug.Assert(response.Length == 16, "response.Length == 16");
+#if NETSTANDARD2_0
+            byte[] responseBuffer = response.ToArray();
+            await transport.Stream.WriteAsync(responseBuffer, 0, responseBuffer.Length, cancellationToken).ConfigureAwait(false);
+#else
             await transport.Stream.WriteAsync(response, cancellationToken).ConfigureAwait(false);
+#endif
 
             return new AuthenticationResult();
         }

--- a/src/MarcusW.VncClient/Protocol/Implementation/Services/Communication/RfbMessageSender.cs
+++ b/src/MarcusW.VncClient/Protocol/Implementation/Services/Communication/RfbMessageSender.cs
@@ -150,11 +150,15 @@ namespace MarcusW.VncClient.Protocol.Implementation.Services.Communication
                     }
                 }
             }
-            catch
+            catch (Exception e)
             {
                 // When the loop was canceled or failed, cancel all remaining queue items
                 SetQueueCancelled();
-                throw;
+
+                if (!(e is OperationCanceledException))
+                {
+                    throw;
+                }
             }
         }
 

--- a/src/MarcusW.VncClient/Protocol/Implementation/Services/Initialization/RfbInitializer.cs
+++ b/src/MarcusW.VncClient/Protocol/Implementation/Services/Initialization/RfbInitializer.cs
@@ -68,7 +68,7 @@ namespace MarcusW.VncClient.Protocol.Implementation.Services.Initialization
             bool shared = _context.Connection.Parameters.AllowSharedConnection;
             _logger.LogDebug("Sending shared-flag ({shared})...", shared);
 
-            await transport.Stream.WriteAsync(new[] { (byte)(shared ? 1 : 0) }, cancellationToken).ConfigureAwait(false);
+            await transport.Stream.WriteAsync(new[] { (byte)(shared ? 1 : 0) }, 0, 1, cancellationToken).ConfigureAwait(false);
         }
 
         private async Task<(Size framebufferSize, PixelFormat pixelFormat, string desktopName)> ReadServerInitAsync(ITransport transport,
@@ -84,7 +84,11 @@ namespace MarcusW.VncClient.Protocol.Implementation.Services.Initialization
 
             // Read desktop name
             ReadOnlyMemory<byte> desktopNameBytes = await transport.Stream.ReadAllAsync((int)desktopNameLength, cancellationToken).ConfigureAwait(false);
+#if NETSTANDARD2_0
+            string desktopName = Encoding.UTF8.GetString(desktopNameBytes.Span.ToArray());
+#else
             string desktopName = Encoding.UTF8.GetString(desktopNameBytes.Span);
+#endif
 
             return (framebufferSize, pixelFormat, desktopName);
         }

--- a/src/MarcusW.VncClient/Protocol/Implementation/Services/Transports/TransportConnector.cs
+++ b/src/MarcusW.VncClient/Protocol/Implementation/Services/Transports/TransportConnector.cs
@@ -55,7 +55,11 @@ namespace MarcusW.VncClient.Protocol.Implementation.Services.Transports
             try
             {
                 // Close (equals Dispose) the client on cancellation to cancel connect attempt
+#if NETSTANDARD2_0
+                using (linkedToken.Register(() => tcpClient.Close()))
+#else
                 await using (linkedToken.Register(() => tcpClient.Close()))
+#endif
                 {
                     linkedToken.ThrowIfCancellationRequested();
 

--- a/src/MarcusW.VncClient/Utils/Index.cs
+++ b/src/MarcusW.VncClient/Utils/Index.cs
@@ -1,0 +1,142 @@
+#if NETSTANDARD2_0
+using System.Runtime.CompilerServices;
+
+namespace System
+{
+    /// <summary>Represent a type can be used to index a collection either from the start or the end.</summary>
+    /// <remarks>
+    /// Index is used by the C# compiler to support the new index syntax
+    /// <code>
+    /// int[] someArray = new int[5] { 1, 2, 3, 4, 5 } ;
+    /// int lastElement = someArray[^1]; // lastElement = 5
+    /// </code>
+    /// </remarks>
+    internal readonly struct Index : IEquatable<Index>
+    {
+        private readonly int _value;
+
+        /// <summary>Construct an Index using a value and indicating if the index is from the start or from the end.</summary>
+        /// <param name="value">The index value. it has to be zero or positive number.</param>
+        /// <param name="fromEnd">Indicating if the index is from the start or from the end.</param>
+        /// <remarks>
+        /// If the Index constructed from the end, index value 1 means pointing at the last element and index value 0 means pointing at beyond last element.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Index(int value, bool fromEnd = false)
+        {
+            if (value < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), "value must be non-negative");
+            }
+
+            if (fromEnd)
+                _value = ~value;
+            else
+                _value = value;
+        }
+
+        // The following private constructors mainly created for perf reason to avoid the checks
+        private Index(int value)
+        {
+            _value = value;
+        }
+
+        /// <summary>Create an Index pointing at first element.</summary>
+        public static Index Start => new Index(0);
+
+        /// <summary>Create an Index pointing at beyond last element.</summary>
+        public static Index End => new Index(~0);
+
+        /// <summary>Create an Index from the start at the position indicated by the value.</summary>
+        /// <param name="value">The index value from the start.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Index FromStart(int value)
+        {
+            if (value < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), "value must be non-negative");
+            }
+
+            return new Index(value);
+        }
+
+        /// <summary>Create an Index from the end at the position indicated by the value.</summary>
+        /// <param name="value">The index value from the end.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Index FromEnd(int value)
+        {
+            if (value < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), "value must be non-negative");
+            }
+
+            return new Index(~value);
+        }
+
+        /// <summary>Returns the index value.</summary>
+        public int Value
+        {
+            get
+            {
+                if (_value < 0)
+                {
+                    return ~_value;
+                }
+                else
+                {
+                    return _value;
+                }
+            }
+        }
+
+        /// <summary>Indicates whether the index is from the start or the end.</summary>
+        public bool IsFromEnd => _value < 0;
+
+        /// <summary>Calculate the offset from the start using the giving collection length.</summary>
+        /// <param name="length">The length of the collection that the Index will be used with. length has to be a positive value</param>
+        /// <remarks>
+        /// For performance reason, we don't validate the input length parameter and the returned offset value against negative values.
+        /// we don't validate either the returned offset is greater than the input length.
+        /// It is expected Index will be used with collections which always have non negative length/count. If the returned offset is negative and
+        /// then used to index a collection will get out of range exception which will be same affect as the validation.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int GetOffset(int length)
+        {
+            var offset = _value;
+            if (IsFromEnd)
+            {
+                // offset = length - (~value)
+                // offset = length + (~(~value) + 1)
+                // offset = length + value + 1
+
+                offset += length + 1;
+            }
+            return offset;
+        }
+
+        /// <summary>Indicates whether the current Index object is equal to another object of the same type.</summary>
+        /// <param name="value">An object to compare with this object</param>
+        public override bool Equals(object? value) => value is Index && _value == ((Index)value)._value;
+
+        /// <summary>Indicates whether the current Index object is equal to another Index object.</summary>
+        /// <param name="other">An object to compare with this object</param>
+        public bool Equals(Index other) => _value == other._value;
+
+        /// <summary>Returns the hash code for this instance.</summary>
+        public override int GetHashCode() => _value;
+
+        /// <summary>Converts integer number to an Index.</summary>
+        public static implicit operator Index(int value) => FromStart(value);
+
+        /// <summary>Converts the value of the current Index object to its equivalent string representation.</summary>
+        public override string ToString()
+        {
+            if (IsFromEnd)
+                return "^" + ((uint)Value).ToString();
+
+            return ((uint)Value).ToString();
+        }
+    }
+}
+#endif

--- a/src/MarcusW.VncClient/Utils/Range.cs
+++ b/src/MarcusW.VncClient/Utils/Range.cs
@@ -1,0 +1,137 @@
+#if NETSTANDARD2_0
+using System.Runtime.CompilerServices;
+
+namespace System
+{
+    /// <summary>Represent a range has start and end indexes.</summary>
+    /// <remarks>
+    /// Range is used by the C# compiler to support the range syntax.
+    /// <code>
+    /// int[] someArray = new int[5] { 1, 2, 3, 4, 5 };
+    /// int[] subArray1 = someArray[0..2]; // { 1, 2 }
+    /// int[] subArray2 = someArray[1..^0]; // { 2, 3, 4, 5 }
+    /// </code>
+    /// </remarks>
+    internal readonly struct Range : IEquatable<Range>
+    {
+        /// <summary>Represent the inclusive start index of the Range.</summary>
+        public Index Start { get; }
+
+        /// <summary>Represent the exclusive end index of the Range.</summary>
+        public Index End { get; }
+
+        /// <summary>Construct a Range object using the start and end indexes.</summary>
+        /// <param name="start">Represent the inclusive start index of the range.</param>
+        /// <param name="end">Represent the exclusive end index of the range.</param>
+        public Range(Index start, Index end)
+        {
+            Start = start;
+            End = end;
+        }
+
+        /// <summary>Indicates whether the current Range object is equal to another object of the same type.</summary>
+        /// <param name="value">An object to compare with this object</param>
+        public override bool Equals(object? value) =>
+            value is Range r &&
+            r.Start.Equals(Start) &&
+            r.End.Equals(End);
+
+        /// <summary>Indicates whether the current Range object is equal to another Range object.</summary>
+        /// <param name="other">An object to compare with this object</param>
+        public bool Equals(Range other) => other.Start.Equals(Start) && other.End.Equals(End);
+
+        /// <summary>Returns the hash code for this instance.</summary>
+        public override int GetHashCode()
+        {
+            return Start.GetHashCode() * 31 + End.GetHashCode();
+        }
+
+        /// <summary>Converts the value of the current Range object to its equivalent string representation.</summary>
+        public override string ToString()
+        {
+            return Start + ".." + End;
+        }
+
+        /// <summary>Create a Range object starting from start index to the end of the collection.</summary>
+        public static Range StartAt(Index start) => new Range(start, Index.End);
+
+        /// <summary>Create a Range object starting from first element in the collection to the end Index.</summary>
+        public static Range EndAt(Index end) => new Range(Index.Start, end);
+
+        /// <summary>Create a Range object starting from first element to the end.</summary>
+        public static Range All => new Range(Index.Start, Index.End);
+
+        /// <summary>Calculate the start offset and length of range object using a collection length.</summary>
+        /// <param name="length">The length of the collection that the range will be used with. length has to be a positive value.</param>
+        /// <remarks>
+        /// For performance reason, we don't validate the input length parameter against negative values.
+        /// It is expected Range will be used with collections which always have non negative length/count.
+        /// We validate the range is inside the length scope though.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public (int Offset, int Length) GetOffsetAndLength(int length)
+        {
+            int start;
+            var startIndex = Start;
+            if (startIndex.IsFromEnd)
+                start = length - startIndex.Value;
+            else
+                start = startIndex.Value;
+
+            int end;
+            var endIndex = End;
+            if (endIndex.IsFromEnd)
+                end = length - endIndex.Value;
+            else
+                end = endIndex.Value;
+
+            if ((uint)end > (uint)length || (uint)start > (uint)end)
+            {
+                throw new ArgumentOutOfRangeException(nameof(length));
+            }
+
+            return (start, end - start);
+        }
+    }
+}
+
+namespace System.Runtime.CompilerServices
+{
+    internal static class RuntimeHelpers
+    {
+        /// <summary>
+        /// Slices the specified array using the specified range.
+        /// </summary>
+        public static T[] GetSubArray<T>(T[] array, Range range)
+        {
+            if (array == null)
+            {
+                throw new ArgumentNullException(nameof(array));
+            }
+
+            (int offset, int length) = range.GetOffsetAndLength(array.Length);
+
+            if (default(T) != null || typeof(T[]) == array.GetType())
+            {
+                // We know the type of the array to be exactly T[].
+
+                if (length == 0)
+                {
+                    return Array.Empty<T>();
+                }
+
+                var dest = new T[length];
+                Array.Copy(array, offset, dest, 0, length);
+                return dest;
+            }
+            else
+            {
+                // The array is actually a U[] where U:T.
+                var dest = (T[])Array.CreateInstance(array.GetType().GetElementType(), length);
+                Array.Copy(array, offset, dest, 0, length);
+                return dest;
+            }
+        }
+    }
+}
+#endif


### PR DESCRIPTION
First off, excellent library, thanks so much for making this available.  You are miles ahead of any other C# VNC library out there and the integration work necessary to drop this into EasyConnect was straightforward and well designed.

This pull request does a few things:

1. Adds support for netstandard2.0, which allowed me to use this library in a .NET Framework application.  Some of the `Span`-based API shims necessary for this aren't *quite* as efficient as their .NET Core counterparts, but they still use `ArrayPool`s to reduce allocations and perform perfectly well in my testing.
2. Adds support for the `ClientCutText` message type.  Figured I would take care of this while I was in there messing about.
3. Calls to `CloseAsync()` no longer throw uncaught exceptions when winding down the message threads.  I made a few changes not to throw exceptions when the message thread workers detect cancellation and to to swallow `OperationCancelledException`, but if there is a better way to close a connection (while not exiting the entire application), feel free to let me know.

Once again, thanks for all of your hard work on this library!