### PR TITLE
Add a handler for custom messages from the server

### DIFF
--- a/src/MarcusW.VncClient/Custom/ICustomMessageHandler.cs
+++ b/src/MarcusW.VncClient/Custom/ICustomMessageHandler.cs
@@ -1,0 +1,7 @@
+namespace MarcusW.VncClient.Custom
+{
+    public interface ICustomMessageHandler
+    {
+        void HandleMessage(object payload);
+    }
+}

--- a/src/MarcusW.VncClient/RfbConnection.cs
+++ b/src/MarcusW.VncClient/RfbConnection.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using MarcusW.VncClient.Custom;
 using MarcusW.VncClient.Output;
 using MarcusW.VncClient.Protocol;
 using MarcusW.VncClient.Rendering;
@@ -23,6 +24,9 @@ namespace MarcusW.VncClient
 
         private readonly object _outputHandlerLock = new object();
         private IOutputHandler? _outputHandler;
+
+        private readonly object _messageHandlerLock = new object();
+        private ICustomMessageHandler? _messageHandler;
 
         private readonly object _interruptionCauseLock = new object();
         private Exception? _interruptionCause;
@@ -72,6 +76,16 @@ namespace MarcusW.VncClient
         {
             get => GetWithLock(ref _outputHandler, _outputHandlerLock);
             set => RaiseAndSetIfChangedWithLock(ref _outputHandler, value, _outputHandlerLock);
+        }
+
+        /// <summary>
+        /// Gets or sets the handler for custom messages from the server.
+        /// Subscribe to <see cref="PropertyChanged"/> to receive change notifications.
+        /// </summary>
+        public ICustomMessageHandler? CustomMessageHandler
+        {
+            get => GetWithLock(ref _messageHandler, _messageHandlerLock);
+            set => RaiseAndSetIfChangedWithLock(ref _messageHandler, value, _messageHandlerLock);
         }
 
         /// <summary>


### PR DESCRIPTION
I need to connect to a server that sends custom messages that are not part of the RFB protocol. In order to parse these messages I can create some custom message types but as far as I can tell, it is not possible to pass any information to the Client.

The idea is similar to `IRenderTarget` and `IOutputHandler` interfaces but instead work in a generic way and allow to pass any object to the handler.