### PR TITLE
Migrate from using Threads to using Tasks for receiving and sending data

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -12,7 +12,7 @@
 
     <PropertyGroup>
         <Product>MarcusW VNC-Client</Product>
-        <VersionNumber>1.0.0-alpha4</VersionNumber>
+        <VersionNumber>1.0.0-alpha5</VersionNumber>
         <Title>High-performance cross-platform VNC-Client library for C#</Title>
         <Authors>Marcus Wichelmann</Authors>
         <Company>Marcus Wichelmann</Company>

--- a/src/MarcusW.VncClient/Protocol/Implementation/Services/Communication/RfbMessageReceiver.cs
+++ b/src/MarcusW.VncClient/Protocol/Implementation/Services/Communication/RfbMessageReceiver.cs
@@ -1,8 +1,11 @@
 using System;
+using System.Buffers;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -54,7 +57,7 @@ namespace MarcusW.VncClient.Protocol.Implementation.Services.Communication
 
         // This method will not catch exceptions so the BackgroundThread base class will receive them,
         // raise a "Failure" and trigger a reconnect.
-        protected override void ThreadWorker(CancellationToken cancellationToken)
+        protected override async Task ThreadWorker(CancellationToken cancellationToken)
         {
             // Get the transport stream so we don't have to call the getter every time
             Debug.Assert(_context.Transport != null, "_context.Transport != null");
@@ -65,28 +68,34 @@ namespace MarcusW.VncClient.Protocol.Implementation.Services.Communication
             ImmutableDictionary<byte, IIncomingMessageType> incomingMessageLookup =
                 _context.SupportedMessageTypes.OfType<IIncomingMessageType>().ToImmutableDictionary(mt => mt.Id);
 
-            Span<byte> messageTypeBuffer = stackalloc byte[1];
-
-            while (!cancellationToken.IsCancellationRequested)
+            var messageTypeBuffer = MemoryPool<byte>.Shared.Rent();
+            try
             {
-                // Read message type
-                if (transportStream.Read(messageTypeBuffer) == 0)
-                    throw new UnexpectedEndOfStreamException("Stream reached its end while reading next message type.");
-                byte messageTypeId = messageTypeBuffer[0];
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    // Read message type
+                    if (await transportStream.ReadAsync(messageTypeBuffer.Memory).ConfigureAwait(false) == 0)
+                        throw new UnexpectedEndOfStreamException("Stream reached its end while reading next message type.");
+                    byte messageTypeId = messageTypeBuffer.Memory.Span[0];
 
-                // Find message type
-                if (!incomingMessageLookup.TryGetValue(messageTypeId, out IIncomingMessageType messageType))
-                    throw new UnexpectedDataException($"Server sent a message of type {messageTypeId} that is not supported by this protocol implementation. "
-                        + "Servers should always check for client support before using protocol extensions.");
+                    // Find message type
+                    if (!incomingMessageLookup.TryGetValue(messageTypeId, out IIncomingMessageType messageType))
+                        throw new UnexpectedDataException($"Server sent a message of type {messageTypeId} that is not supported by this protocol implementation. "
+                            + "Servers should always check for client support before using protocol extensions.");
 
-                _logger.LogDebug("Received message: {name}({id})", messageType.Name, messageTypeId);
+                    _logger.LogDebug("Received message: {name}({id})", messageType.Name, messageTypeId);
 
-                // Ensure the message type is marked as used
-                if (!messageType.IsStandardMessageType)
-                    _state.EnsureMessageTypeIsMarkedAsUsed(messageType);
+                    // Ensure the message type is marked as used
+                    if (!messageType.IsStandardMessageType)
+                        _state.EnsureMessageTypeIsMarkedAsUsed(messageType);
 
-                // Read the message
-                messageType.ReadMessage(transport, cancellationToken);
+                    // Read the message
+                    messageType.ReadMessage(transport, cancellationToken);
+                }
+            }
+            finally
+            {
+                messageTypeBuffer.Dispose();
             }
         }
     }

--- a/src/MarcusW.VncClient/Utils/BackgroundThread.cs
+++ b/src/MarcusW.VncClient/Utils/BackgroundThread.cs
@@ -10,13 +10,8 @@ namespace MarcusW.VncClient.Utils
     /// </summary>
     public abstract class BackgroundThread : IBackgroundThread
     {
-        private readonly Thread _thread;
-
-        private bool _started;
-        private readonly object _startLock = new object();
-
         private readonly CancellationTokenSource _stopCts = new CancellationTokenSource();
-        private readonly TaskCompletionSource<object?> _completedTcs = new TaskCompletionSource<object?>();
+        private Lazy<Task> _task;
 
         private volatile bool _disposed;
 
@@ -27,15 +22,18 @@ namespace MarcusW.VncClient.Utils
         /// Initializes a new instance of the <see cref="BackgroundThread"/>.
         /// </summary>
         /// <param name="name">The thread name.</param>
+        [Obsolete("The name field is no longer used")]
         protected BackgroundThread(string name)
+            : this()
         {
-            if (name == null)
-                throw new ArgumentNullException(nameof(name));
+        }
 
-            _thread = new Thread(ThreadStart) {
-                Name = name,
-                IsBackground = true
-            };
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BackgroundThread"/>.
+        /// </summary>
+        protected BackgroundThread()
+        {
+            _task = new Lazy<Task>(() => ThreadWorker(_stopCts.Token));
         }
 
         /// <summary>
@@ -49,13 +47,14 @@ namespace MarcusW.VncClient.Utils
             if (_disposed)
                 throw new ObjectDisposedException(nameof(BackgroundThread));
 
-            lock (_startLock)
+            try
             {
-                if (_started)
-                    throw new InvalidOperationException("Thread already started.");
-
-                _thread.Start(_stopCts.Token);
-                _started = true;
+                // Do your work...
+                _ = _task.Value;
+            }
+            catch (Exception exception) when (!(exception is OperationCanceledException || exception is ThreadAbortException))
+            {
+                Failed?.Invoke(this, new BackgroundThreadFailedEventArgs(exception));
             }
         }
 
@@ -65,50 +64,26 @@ namespace MarcusW.VncClient.Utils
         /// <remarks>
         /// It is safe to call this method multiple times.
         /// </remarks>
-        protected Task StopAndWaitAsync()
+        protected async Task StopAndWaitAsync()
         {
             if (_disposed)
                 throw new ObjectDisposedException(nameof(BackgroundThread));
-
-            lock (_startLock)
-            {
-                if (!_started)
-                    throw new InvalidOperationException("Thread has not been started.");
-            }
 
             // Tell the thread to stop
             _stopCts.Cancel();
 
             // Wait for completion
-            return _completedTcs.Task;
+            if (_task.IsValueCreated)
+            {
+                await _task.Value.ConfigureAwait(false);
+            }
         }
 
         /// <summary>
         /// Executes the work that should happen in the background.
         /// </summary>
         /// <param name="cancellationToken">The cancellation token that tells the method implementation when to complete.</param>
-        protected abstract void ThreadWorker(CancellationToken cancellationToken);
-
-        private void ThreadStart(object? parameter)
-        {
-            Debug.Assert(parameter != null, nameof(parameter) + " != null");
-            var cancellationToken = (CancellationToken)parameter;
-
-            try
-            {
-                // Do your work...
-                ThreadWorker(cancellationToken);
-            }
-            catch (Exception exception) when (!(exception is OperationCanceledException || exception is ThreadAbortException))
-            {
-                Failed?.Invoke(this, new BackgroundThreadFailedEventArgs(exception));
-            }
-            finally
-            {
-                // Notify stop method that thread has completed
-                _completedTcs.TrySetResult(null);
-            }
-        }
+        protected abstract Task ThreadWorker(CancellationToken cancellationToken);
 
         /// <inheritdoc />
         public void Dispose() => Dispose(true);
@@ -120,25 +95,7 @@ namespace MarcusW.VncClient.Utils
 
             if (disposing)
             {
-                try
-                {
-                    // Ensure the thread is stopped
-                    _stopCts.Cancel();
-                    if (_thread.IsAlive)
-                    {
-                        // Block and wait for completion or hard-kill the thread after 1 second
-                        if (!_thread.Join(TimeSpan.FromSeconds(1)))
-                            _thread.Abort();
-                    }
-                }
-                catch
-                {
-                    // Ignore
-                }
-
-                // Just to be sure...
-                _completedTcs.TrySetResult(null);
-
+                _stopCts.Cancel();
                 _stopCts.Dispose();
             }
 

--- a/tests/MarcusW.VncClient.Tests/Utils/BackgroundThreadTests.cs
+++ b/tests/MarcusW.VncClient.Tests/Utils/BackgroundThreadTests.cs
@@ -64,10 +64,10 @@ namespace MarcusW.VncClient.Tests.Utils
 
             public new Task StopAndWaitAsync() => base.StopAndWaitAsync();
 
-            protected override void ThreadWorker(CancellationToken cancellationToken)
+            protected override async Task ThreadWorker(CancellationToken cancellationToken)
             {
                 while (!cancellationToken.IsCancellationRequested)
-                    Thread.Sleep(10);
+                    await Task.Delay(10);
             }
         }
     }


### PR DESCRIPTION
This PR changes the background tasks from using threads to instead use tasks.

The reason for this change is that using Threads using ThreadStart will keep the thread reserved for that background job, even though that job might just wait for input. That means no-one else can use that thread which might lead to depleting the thread pool if you had multiple VNC connections open. It thus isn't very scalable. 
The second benefit of not using threads is that exceptions can't be handled in threads at all, which leads to unhandleable problems like in #25.

The only issue with my implementation is that any exceptions thrown get silently eaten until the Task is awaited (which in my case happens when `StopSendLoopAsync()` is called). I don't really know of a good solution for this, however feedback is welcome. It might also be small enough to be considered a "won't fix™".

If you have any questions about my implementation, please reach out.

Closes #25 