### PR TITLE
ZRLE Subencoding 128 incorrectly always assumes 3 bytes per pixel

### DIFF
--- a/src/MarcusW.VncClient/Protocol/Implementation/EncodingTypes/Frame/ZrleEncodingType.cs
+++ b/src/MarcusW.VncClient/Protocol/Implementation/EncodingTypes/Frame/ZrleEncodingType.cs
@@ -324,6 +324,8 @@ namespace MarcusW.VncClient.Protocol.Implementation.EncodingTypes.Frame
             {
                 fixed (byte* bufferPtr = buffer)
                 {
+                    int bytesPerPixel = cPixelFormat.BytesPerPixel;
+
                     // We need to read on demand, because we cannot tell the number of bytes to read in advance
                     Span<byte> runLengthReadBuffer = stackalloc byte[1];
 
@@ -331,10 +333,10 @@ namespace MarcusW.VncClient.Protocol.Implementation.EncodingTypes.Frame
                     while (pixelsRemaining > 0)
                     {
                         // Read pixel data and first run-length byte
-                        stream.ReadAll(buffer.Slice(0, 4));
+                        stream.ReadAll(buffer.Slice(0, bytesPerPixel + 1));
 
                         // Calculate run-length
-                        byte runLengthByte = buffer[3];
+                        byte runLengthByte = buffer[bytesPerPixel];
                         int runLength = runLengthByte + 1;
                         while (runLengthByte == 255)
                         {


### PR DESCRIPTION
When processing a ZRLE tile with subencoding 128 - the code incorrectly assumes each pixel is 3 bytes (CPIXEL).

Modified the code to read the correct number of bytes per pixel as pixel data, and then read the run length.

See section [7.7.5 of the RFC](https://datatracker.ietf.org/doc/html/rfc6143#:~:text=packed%20palette%20types.-,128%3A%20%20Plain%20RLE.,-The%20data%20consists)


PS. Incorporated this fix into my PR #12 